### PR TITLE
Change blog-card headline to not-uppercase

### DIFF
--- a/_assets/css/elevate_theme/_layout.scss
+++ b/_assets/css/elevate_theme/_layout.scss
@@ -1286,6 +1286,10 @@ section {
     }
 }
 
+.blog-card h4 {
+  text-transform: none;
+}
+
 // ============ mobile hero section =========== //
 
 .mobile-hero {


### PR DESCRIPTION
Changed blog-card headline `text-transform` to None so headlines on the Blog page will no longer be uppercase.

This does not affect "non-blog" cards such as the ones on the [Treatment Programs](https://5b858a6b93a57a4734333f6c.preview.siteleaf.com/services/treatment-programs/) page.

@cunning-folk Let me know if this is closer to how you want it?

(Will resolve #141)

![image](https://user-images.githubusercontent.com/22042343/49956742-f8c4c600-fed3-11e8-8a67-09f05a761dc2.png)

