### PR TITLE
Add meta keywords

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,8 +50,9 @@ defaults:
   values:
     layout: post
     permalink: "/blog/:title/"
-    author: 
-    post_image: 
+    author:
+    post_image:
+    seo_keywords:
 - scope:
     path: ''
     type: pages
@@ -64,9 +65,10 @@ defaults:
     permalink: "/blog/authors/:title/"
     layout: author
     credentials: Ph.D.
-    medium: 
+    medium:
 description: Elevate360 is a boutique addiction treatment program in Midtown Manhattan.
 seo_subtitle: Outpatient addiction treatment in Midtown Manhattan
+seo_site_keywords: addiction, addiction treatment
 url: https://elevate360.com
 phone_number: 212-204-8430
 show_excerpts: false

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
+{% assign keywords = site.seo_site_keywords %}
+{% if page['seo_keywords'] %}
+  {% assign keywords = page['seo_keywords'] %}
+{% endif %}
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="index, follow">
+    <meta name="keywords" content="{{ page.keywords }}">
 
     {% include head.html %}
     {% seo %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="index, follow">
-    <meta name="keywords" content="{{ page.keywords }}">
+    <meta name="keywords" content="{{ keywords }}">
 
     {% include head.html %}
     {% seo %}

--- a/_layouts/markdown.html
+++ b/_layouts/markdown.html
@@ -4,6 +4,7 @@
     <meta name="robots" content="index, follow">
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="keywords" content="{{ site.seo_site_keywords }}">
 
     {% include head.html %}
     {% seo %}


### PR DESCRIPTION
Adds `<meta>` keywords tags for all pages.

Site keywords are set in `_config.yml`, so may be edited in Siteleaf by going to Settings.

Keywords for specific blog posts are set in the `seo_keywords` metadata field.  If none is specified, keywords for that blog post will fall back to the Site keywords.

Resolves #151 