### PR TITLE
Add jekyll-feed plugin / Atom feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,7 @@ plugins:
 - jekyll-assets
 - jekyll-seo-tag
 - jekyll-sitemap
+- jekyll-feed
 exclude:
 - Gemfile.lock
 - node_modules

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="index, follow">
     <meta name="keywords" content="{{ keywords }}">
+    {% feed_meta %}
 
     {% include head.html %}
     {% seo %}

--- a/_layouts/markdown.html
+++ b/_layouts/markdown.html
@@ -5,6 +5,8 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="keywords" content="{{ site.seo_site_keywords }}">
+    {% feed_meta %}
+
 
     {% include head.html %}
     {% seo %}


### PR DESCRIPTION
* Activates the [jekyll-feed](https://github.com/jekyll/jekyll-feed)  plugin (we already had it in the Gemfile)
* Creates an Atom feed at `/feed.xml` containing all current and future blog posts
* Uses `{% feed_meta %}` to add `<link>` tags to the feed on all pages using the `default` and `markdown` templates
* Bonus: It looks like the `feed.xml` file is in the generated site, but not in the repo.  So no need to add it to `.gitignore`
* Resolves #154 