### PR TITLE
Add page for Group Psychotherapy Offerings

### DIFF
--- a/_assets/css/elevate_theme/_layout.scss
+++ b/_assets/css/elevate_theme/_layout.scss
@@ -373,7 +373,7 @@ a.nav-icon {
                 justify-content: space-between;
                 flex-wrap: nowrap;
                 width: 100%;
-                padding-bottom: 1.5em;
+                margin-bottom: 1.5em;
 
                 .page-photo {
                     flex-basis: 33%;

--- a/_assets/css/elevate_theme/_layout.scss
+++ b/_assets/css/elevate_theme/_layout.scss
@@ -373,6 +373,7 @@ a.nav-icon {
                 justify-content: space-between;
                 flex-wrap: nowrap;
                 width: 100%;
+                padding-bottom: 1.5em;
 
                 .page-photo {
                     flex-basis: 33%;

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ collections:
   authors:
     title: Authors
     output: true
+  group-psychotherapy:
+    title: Group Psychotherapy
+    output: false
   home:
     title: Home
     output: false
@@ -50,9 +53,9 @@ defaults:
   values:
     layout: post
     permalink: "/blog/:title/"
-    author: 
-    post_image: 
-    seo_keywords: 
+    author:
+    post_image:
+    seo_keywords:
 - scope:
     path: ''
     type: pages
@@ -65,7 +68,7 @@ defaults:
     permalink: "/blog/authors/:title/"
     layout: author
     credentials: Ph.D.
-    medium: 
+    medium:
 description: Elevate360 is a boutique addiction treatment program in Midtown Manhattan.
 seo_subtitle: Outpatient addiction treatment in Midtown Manhattan
 seo_site_keywords: addiction, addiction treatment, mental health treatment

--- a/_group-psychotherapy/attorneys-in-recovery.markdown
+++ b/_group-psychotherapy/attorneys-in-recovery.markdown
@@ -2,7 +2,6 @@
 title: Attorneys in Recovery
 meeting_time: Thursdays 6:00pm-7:00pm
 position: 5
-layout: tertiary
 ---
 
 Dr. Sarah Church has created a 60-minute group designed for attorneys in recovery.  Legal professionals experience significantly higher rates of substance use and mental health disorders when compared to employees in other occupations, due to the nature of the legal profession which includes heavy workloads and intense competition.  Additionally, many attorneys experience frequent antagonistic interactions with other attorneys which is compounded by pressure to satisfy demanding clients while simultaneously striving to log billable hours and create new business. Attorneys encounter unique challenges in the recovery process as they attempt to achieve a healthy work-life balance.  Often, they have minimal control over their assignments and schedules and may be expected to be available for round the clock responses, which leaves little time for rest and relaxation. All of this takes place in a culture which may normalize the consumption of alcohol as part of the work environment. This treatment group provides support and will offer skills and strategies for preventing relapse and coping with stress, negative moods and achieving a healthy sustainable lifestyle.

--- a/_group-psychotherapy/attorneys-in-recovery.markdown
+++ b/_group-psychotherapy/attorneys-in-recovery.markdown
@@ -1,10 +1,7 @@
 ---
 title: Attorneys in Recovery
 meeting_time: Thursdays 6:00pm-7:00pm
-date: 2019-01-24 16:22:00 -04:00
 position: 5
-back_href: "/services/treatment-programs"
-back_title: Treatment Programs
 layout: tertiary
 ---
 

--- a/_group-psychotherapy/attorneys-in-recovery.markdown
+++ b/_group-psychotherapy/attorneys-in-recovery.markdown
@@ -1,0 +1,11 @@
+---
+title: Attorneys in Recovery
+meeting_time: Thursdays 6:00pm-7:00pm
+date: 2019-01-24 16:22:00 -04:00
+position: 5
+back_href: "/services/treatment-programs"
+back_title: Treatment Programs
+layout: tertiary
+---
+
+Dr. Sarah Church has created a 60-minute group designed for attorneys in recovery.  Legal professionals experience significantly higher rates of substance use and mental health disorders when compared to employees in other occupations, due to the nature of the legal profession which includes heavy workloads and intense competition.  Additionally, many attorneys experience frequent antagonistic interactions with other attorneys which is compounded by pressure to satisfy demanding clients while simultaneously striving to log billable hours and create new business. Attorneys encounter unique challenges in the recovery process as they attempt to achieve a healthy work-life balance.  Often, they have minimal control over their assignments and schedules and may be expected to be available for round the clock responses, which leaves little time for rest and relaxation. All of this takes place in a culture which may normalize the consumption of alcohol as part of the work environment. This treatment group provides support and will offer skills and strategies for preventing relapse and coping with stress, negative moods and achieving a healthy sustainable lifestyle.

--- a/_group-psychotherapy/cbt-relapse.markdown
+++ b/_group-psychotherapy/cbt-relapse.markdown
@@ -2,7 +2,6 @@
 title: CBT Relapse Prevention Group
 meeting_time: Mondays 12:30pm-2:00pm  
 position: 3
-layout: tertiary
 ---
 
 Dr. Amy J. Colley from Elevate360 will be leading a skill building group for individuals who are recently abstinent and are seeking support in early recovery. The group will meet for 90 minutes and run for 12 weeks. The goal of the group is to enhance self-control and raise awareness of problematic thoughts and behaviors and replace them with new more effective thoughts, skills and strategies for maintaining abstinence. Based on a cognitive behavioral model established at Yale University School of Medicine, we will focus on topics such as exploring positive and negative consequences of continued use, self-monitoring to recognize craving early on, identifying internal and external triggers, coping with cravings, practicing refusal skills, articulating goals and addressing ambivalence.  Members will have homework to support skills learned in the group meetings. Dr. Colley welcomes collaboration with group members’ individual therapists with their permission.

--- a/_group-psychotherapy/cbt-relapse.markdown
+++ b/_group-psychotherapy/cbt-relapse.markdown
@@ -1,7 +1,6 @@
 ---
 title: CBT Relapse Prevention Group
 meeting_time: Mondays 12:30pm-2:00pm  
-date: 2019-01-24 16:24:00 -04:00
 position: 3
 layout: tertiary
 ---

--- a/_group-psychotherapy/cbt-relapse.markdown
+++ b/_group-psychotherapy/cbt-relapse.markdown
@@ -1,0 +1,9 @@
+---
+title: CBT Relapse Prevention Group
+meeting_time: Mondays 12:30pm-2:00pm  
+date: 2019-01-24 16:24:00 -04:00
+position: 3
+layout: tertiary
+---
+
+Dr. Amy J. Colley from Elevate360 will be leading a skill building group for individuals who are recently abstinent and are seeking support in early recovery. The group will meet for 90 minutes and run for 12 weeks. The goal of the group is to enhance self-control and raise awareness of problematic thoughts and behaviors and replace them with new more effective thoughts, skills and strategies for maintaining abstinence. Based on a cognitive behavioral model established at Yale University School of Medicine, we will focus on topics such as exploring positive and negative consequences of continued use, self-monitoring to recognize craving early on, identifying internal and external triggers, coping with cravings, practicing refusal skills, articulating goals and addressing ambivalence.  Members will have homework to support skills learned in the group meetings. Dr. Colley welcomes collaboration with group members’ individual therapists with their permission.

--- a/_group-psychotherapy/intro.markdown
+++ b/_group-psychotherapy/intro.markdown
@@ -1,0 +1,14 @@
+---
+title: Group Psychotherapy Offerings
+meeting_time:
+date: 2019-01-24 16:24:00 -04:00
+position: 1
+back_href: "/services/treatment-programs"
+back_title: Treatment Programs
+layout: tertiary
+---
+
+All groups take place at __Elevate360, 369 Lexington Avenue, Suite 14A (at 41st St.)__  We welcome participants who receive individual treatment with other providers.  If you have any questions about any of our groups or would like to refer a patient who might benefit from additional support, please call us at !PHONE_NUMBER!.  All treatment is eligible for reimbursement through out-of-network benefits.
+
+Initial Group Assessment: $275  
+Group Fee: $125 per session  

--- a/_group-psychotherapy/intro.markdown
+++ b/_group-psychotherapy/intro.markdown
@@ -2,7 +2,6 @@
 title: Group Psychotherapy Offerings
 meeting_time:
 position: 1
-layout: tertiary
 ---
 
 All groups take place at __Elevate360, 369 Lexington Avenue, Suite 14A (at 41st St.)__  We welcome participants who receive individual treatment with other providers.  If you have any questions about any of our groups or would like to refer a patient who might benefit from additional support, please call us at !PHONE_NUMBER!.  All treatment is eligible for reimbursement through out-of-network benefits.

--- a/_group-psychotherapy/intro.markdown
+++ b/_group-psychotherapy/intro.markdown
@@ -1,10 +1,7 @@
 ---
 title: Group Psychotherapy Offerings
 meeting_time:
-date: 2019-01-24 16:24:00 -04:00
 position: 1
-back_href: "/services/treatment-programs"
-back_title: Treatment Programs
 layout: tertiary
 ---
 

--- a/_group-psychotherapy/psychodynamic.markdown
+++ b/_group-psychotherapy/psychodynamic.markdown
@@ -1,10 +1,7 @@
 ---
 title: Psychodynamic Therapy Group for Substance Use Issues
 meeting_time: Tuesdays 6:00pm-7:00pm  
-date: 2019-01-24 16:24:00 -04:00
 position: 4
-back_href: "/services/treatment-programs"
-back_title: Treatment Programs
 layout: tertiary
 ---
 

--- a/_group-psychotherapy/psychodynamic.markdown
+++ b/_group-psychotherapy/psychodynamic.markdown
@@ -2,7 +2,6 @@
 title: Psychodynamic Therapy Group for Substance Use Issues
 meeting_time: Tuesdays 6:00pm-7:00pm  
 position: 4
-layout: tertiary
 ---
 
 Dr. Bill Gottdiener will be leading a psychodynamic therapy group that will meet for 60 minutes and run for 24 weeks. Group members will be supported in discussing their personal experiences and will be taught expressive techniques to assist in identifying and working through interpersonal relationship issues.Group members will be encouraged to examine how alcohol and drugs are used in relation to their emotions and behaviors and will learn methods of problem solving that avoid the use of alcohol and drugs.The safe-space of the group will enable group members to address and resolve difficult feelings and problematic relationship patterns that may arise in the group.As members are better able to understand and express their internal experiences and emotions, they will be less inclined to use drugs and alcohol in problematic ways.

--- a/_group-psychotherapy/psychodynamic.markdown
+++ b/_group-psychotherapy/psychodynamic.markdown
@@ -1,0 +1,11 @@
+---
+title: Psychodynamic Therapy Group for Substance Use Issues
+meeting_time: Tuesdays 6:00pm-7:00pm  
+date: 2019-01-24 16:24:00 -04:00
+position: 4
+back_href: "/services/treatment-programs"
+back_title: Treatment Programs
+layout: tertiary
+---
+
+Dr. Bill Gottdiener will be leading a psychodynamic therapy group that will meet for 60 minutes and run for 24 weeks. Group members will be supported in discussing their personal experiences and will be taught expressive techniques to assist in identifying and working through interpersonal relationship issues.Group members will be encouraged to examine how alcohol and drugs are used in relation to their emotions and behaviors and will learn methods of problem solving that avoid the use of alcohol and drugs.The safe-space of the group will enable group members to address and resolve difficult feelings and problematic relationship patterns that may arise in the group.As members are better able to understand and express their internal experiences and emotions, they will be less inclined to use drugs and alcohol in problematic ways.

--- a/_group-psychotherapy/womens-mindfulness.markdown
+++ b/_group-psychotherapy/womens-mindfulness.markdown
@@ -1,11 +1,11 @@
 ---
 title: Women’s Mindfulness Support Network
+meeting_time: Wednesdays 11:00am-12:30pm
 date: 2019-01-24 16:22:00 -04:00
-position: 1
+position: 2
 back_href: "/services/treatment-programs"
 back_title: Treatment Programs
 layout: tertiary
 ---
 
-Wednesdays at 11:00am-12:30pm
-We’re delighted to share that we are recruiting patients for our eight-week mindfulness-based psychotherapy group for women who are interested in exploring their relationship with alcohol. Dr. Jennifer Smith will lead this group in their discussions examining the positive and negative consequences of alcohol use in their lives and will integrate mindfulness meditation practices into an exploration of motivation to change and traditional relapse prevention. Each week will incorporate a variety of techniques utilizing in mindfulness-based addiction treatment which include ‘awareness of breath’, progressive muscle relaxation, and ‘body scan’. Goals for the group members will be individualized and may include a reduction in stress and increased ability to respond to negative thoughts, sensations, and emotions with an attitude of nonjudgmental, acceptance, and present-moment awareness.  Participants will be asked to share their struggles and solution suggestions with one another -as much as they are comfortable to do so.  “Homework” assignments will be given each week as increased practice of mindfulness is associated with improved outcome. 
+We’re delighted to share that we are recruiting patients for our eight-week mindfulness-based psychotherapy group for women who are interested in exploring their relationship with alcohol. Dr. Jennifer Smith will lead this group in their discussions examining the positive and negative consequences of alcohol use in their lives and will integrate mindfulness meditation practices into an exploration of motivation to change and traditional relapse prevention. Each week will incorporate a variety of techniques utilizing in mindfulness-based addiction treatment which include ‘awareness of breath’, progressive muscle relaxation, and ‘body scan’. Goals for the group members will be individualized and may include a reduction in stress and increased ability to respond to negative thoughts, sensations, and emotions with an attitude of nonjudgmental, acceptance, and present-moment awareness.  Participants will be asked to share their struggles and solution suggestions with one another -as much as they are comfortable to do so.  “Homework” assignments will be given each week as increased practice of mindfulness is associated with improved outcome.

--- a/_group-psychotherapy/womens-mindfulness.markdown
+++ b/_group-psychotherapy/womens-mindfulness.markdown
@@ -1,0 +1,11 @@
+---
+title: Women’s Mindfulness Support Network
+date: 2019-01-24 16:22:00 -04:00
+position: 1
+back_href: "/services/treatment-programs"
+back_title: Treatment Programs
+layout: tertiary
+---
+
+Wednesdays at 11:00am-12:30pm
+We’re delighted to share that we are recruiting patients for our eight-week mindfulness-based psychotherapy group for women who are interested in exploring their relationship with alcohol. Dr. Jennifer Smith will lead this group in their discussions examining the positive and negative consequences of alcohol use in their lives and will integrate mindfulness meditation practices into an exploration of motivation to change and traditional relapse prevention. Each week will incorporate a variety of techniques utilizing in mindfulness-based addiction treatment which include ‘awareness of breath’, progressive muscle relaxation, and ‘body scan’. Goals for the group members will be individualized and may include a reduction in stress and increased ability to respond to negative thoughts, sensations, and emotions with an attitude of nonjudgmental, acceptance, and present-moment awareness.  Participants will be asked to share their struggles and solution suggestions with one another -as much as they are comfortable to do so.  “Homework” assignments will be given each week as increased practice of mindfulness is associated with improved outcome. 

--- a/_group-psychotherapy/womens-mindfulness.markdown
+++ b/_group-psychotherapy/womens-mindfulness.markdown
@@ -2,7 +2,6 @@
 title: Women’s Mindfulness Support Network
 meeting_time: Wednesdays 11:00am-12:30pm
 position: 2
-layout: tertiary
 ---
 
 We’re delighted to share that we are recruiting patients for our eight-week mindfulness-based psychotherapy group for women who are interested in exploring their relationship with alcohol. Dr. Jennifer Smith will lead this group in their discussions examining the positive and negative consequences of alcohol use in their lives and will integrate mindfulness meditation practices into an exploration of motivation to change and traditional relapse prevention. Each week will incorporate a variety of techniques utilizing in mindfulness-based addiction treatment which include ‘awareness of breath’, progressive muscle relaxation, and ‘body scan’. Goals for the group members will be individualized and may include a reduction in stress and increased ability to respond to negative thoughts, sensations, and emotions with an attitude of nonjudgmental, acceptance, and present-moment awareness.  Participants will be asked to share their struggles and solution suggestions with one another -as much as they are comfortable to do so.  “Homework” assignments will be given each week as increased practice of mindfulness is associated with improved outcome.

--- a/_group-psychotherapy/womens-mindfulness.markdown
+++ b/_group-psychotherapy/womens-mindfulness.markdown
@@ -1,10 +1,7 @@
 ---
 title: Women’s Mindfulness Support Network
 meeting_time: Wednesdays 11:00am-12:30pm
-date: 2019-01-24 16:22:00 -04:00
 position: 2
-back_href: "/services/treatment-programs"
-back_title: Treatment Programs
 layout: tertiary
 ---
 

--- a/_includes/services_card.html
+++ b/_includes/services_card.html
@@ -1,9 +1,11 @@
+{% assign excerpt_with_phone_num = include.card.excerpt | replace: '!PHONE_NUMBER!', site.phone_number %}
+
 <div class="card services-card">
     <div class="card-inner">
       <h4>{{ include.card.title }}</h4>
-      {{ include.card.excerpt }}
+      {{ excerpt_with_phone_num }}
     </div>
-    {% if  include.card.content.size > include.card.excerpt.size %}
+    {% if include.card.content.size > include.card.excerpt.size %}
         <a href="{{ include.card.url }}" class="learn-more">Learn More &#x2192;</a>
     {% endif %}
 </div>

--- a/_layouts/services.html
+++ b/_layouts/services.html
@@ -1,12 +1,13 @@
 ---
 layout: default
 ---
+{% assign content_with_phone_num = page.content | replace: '!PHONE_NUMBER!', site.phone_number %}
 
 {% include section-type2.html
     id="service_subsection_header"
     h1="Our Services"
     h2=page.title
-    content=content
+    content=content_with_phone_num
 %}
 
 <section id="services_grid">

--- a/_layouts/tertiary.html
+++ b/_layouts/tertiary.html
@@ -17,6 +17,8 @@ full_title: A longer title than you want in the <title> tag
 The `back_title` and `photo_alt` are not used if their respect `back_href` and `photo` are not utilized.
 {% endcomment %}
 
+{% assign content_with_phone_num = page.content | replace: '!PHONE_NUMBER!', site.phone_number %}
+
 <section class="content-page tertiary">
   <header>
     {% if page.back_href %}
@@ -34,7 +36,7 @@ The `back_title` and `photo_alt` are not used if their respect `back_href` and `
       </div>
     {% endif %}
     <div class="tertiary-content-inner">
-      {{ content }}
+      {{ content_with_phone_num }}
     </div>
   </article>
 <section>

--- a/_treatment-programs/additional-services.markdown
+++ b/_treatment-programs/additional-services.markdown
@@ -1,7 +1,7 @@
 ---
 title: Additional Services
 date: 2018-09-07 16:22:00 -04:00
-position: 3
+position: 4
 back_href: "/services/treatment-programs"
 back_title: Treatment Programs
 layout: tertiary

--- a/_treatment-programs/group-psychotherapy.markdown
+++ b/_treatment-programs/group-psychotherapy.markdown
@@ -1,0 +1,13 @@
+---
+title: Group Psychotherapy Offerings
+date: 2019-01-24 16:22:00 -04:00
+position: 3
+back_href: "/services/treatment-programs"
+back_title: Treatment Programs
+layout: tertiary
+---
+
+All groups take place at Elevate360, 369 Lexington Avenue, Suite 14A (at 41st St.)  We welcome participants who receive individual treatment with other providers.  If you have any questions about any of our groups or would like to refer a patient who might benefit from additional support, please call us at !PHONE_NUMBER!.  All treatment is eligible for reimbursement through out-of-network benefits.
+
+Initial Group Assessment: $275
+Group Fee: $125 per session

--- a/_treatment-programs/medication.markdown
+++ b/_treatment-programs/medication.markdown
@@ -1,7 +1,7 @@
 ---
 title: Medication
 date: 2018-09-07 16:22:00 -04:00
-position: 4
+position: 5
 back_href: "/services/treatment-programs"
 back_title: Treatment Programs
 layout: tertiary

--- a/services/treatment-programs/group-psychotherapy.html
+++ b/services/treatment-programs/group-psychotherapy.html
@@ -1,32 +1,24 @@
 ---
 layout: default
 collection: group-psychotherapy
+title: Group Psychotherapy Offerings
+back_href: "/services/treatment-programs"
+back_title: Treatment Programs
+
 ---
 
-{% comment %}
-This page is the same as Tertiary layout, but iterate through the collection.
-{% endcomment %}
+{% assign collection = site[page.collection] | sort: 'position' %}
 
-{% assign collection = site[page.collection] %}
 {% for doc in collection %}
+  {% assign content_with_phone_num = doc.content | replace: '!PHONE_NUMBER!', site.phone_number %}
   <section class="content-page tertiary">
     <header>
-      {% if page.back_href %}
-        <p class="back-link">
-          <a href="{{ page.back_href }}">&#x2190; Back{% if page.back_title %} to {{ page.back_title }}{% endif %}</a>
-        </p>
-      {% endif %}
-      <h1 class="small">{% if page.full_title %}{{ page.full_title }}{% else %}{{ page.title }}{% endif %}</h1>
+      <h1 class="small">{{ doc.title }}</h1>
+      <h4>{{ doc.meeting_time }}</h4>
     </header>
     <article>
-      {% if page.photo %}
-        {% assign page_photo = page.photo | remove_first: '/uploads/' | url_decode %}
-        <div class="page-photo{% if page.photo_left == true %} photo-left{% endif %}">
-          <img src="{% asset '{{ page_photo }}' @path %}" alt="{% if page.photo_alt %}{{ page.photo_alt }}{% else %}{{ page.title }}{% endif %}">
-        </div>
-      {% endif %}
       <div class="tertiary-content-inner">
-        {{ doc.content }}
+        {{ content_with_phone_num }}
       </div>
     </article>
   <section>

--- a/services/treatment-programs/group-psychotherapy.html
+++ b/services/treatment-programs/group-psychotherapy.html
@@ -1,0 +1,33 @@
+---
+layout: default
+collection: group-psychotherapy
+---
+
+{% comment %}
+This page is the same as Tertiary layout, but iterate through the collection.
+{% endcomment %}
+
+{% assign collection = site[page.collection] %}
+{% for doc in collection %}
+  <section class="content-page tertiary">
+    <header>
+      {% if page.back_href %}
+        <p class="back-link">
+          <a href="{{ page.back_href }}">&#x2190; Back{% if page.back_title %} to {{ page.back_title }}{% endif %}</a>
+        </p>
+      {% endif %}
+      <h1 class="small">{% if page.full_title %}{{ page.full_title }}{% else %}{{ page.title }}{% endif %}</h1>
+    </header>
+    <article>
+      {% if page.photo %}
+        {% assign page_photo = page.photo | remove_first: '/uploads/' | url_decode %}
+        <div class="page-photo{% if page.photo_left == true %} photo-left{% endif %}">
+          <img src="{% asset '{{ page_photo }}' @path %}" alt="{% if page.photo_alt %}{{ page.photo_alt }}{% else %}{{ page.title }}{% endif %}">
+        </div>
+      {% endif %}
+      <div class="tertiary-content-inner">
+        {{ doc.content }}
+      </div>
+    </article>
+  <section>
+{% endfor %}


### PR DESCRIPTION
Adding a page for Group Psychotherapy Offerings.

* Located under Services / Treatment Programs
* Has its own page at `/services/treatment-programs/group-psychotherapy/`
* Added a new Collection; one doc for each offering
* Client can edit info on Siteleaf by editing the docs in the __Group Psychotherapy__ collection
* Client can edit Title or Meeting Time by editing the respective fields
* Phone number is soft-coded
* Resolves #167 