### PR TITLE
Seo enhancement

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,19 +4,27 @@ timezone: America/New_York
 collections:
   about-us:
     title: About Us
+    page_title: About Us
     output: false
+    seo_description:
+    seo_keywords:
   authors:
     title: Authors
     output: true
   group-psychotherapy:
     title: Group Psychotherapy
+    page_title: Group Psychotherapy
     output: false
+    seo_description:
+    seo_keywords:
   home:
     title: Home
-    output: false
+    page_title: Welcome to Elevate360 Wellness
+    seo_description:
     seo_keywords: |-
       private outpatient drug rehab centers, outpatient substance abuse treatment near me, outpatient drug rehab programs,
       intensive outpatient program near me, outpatient rehab for substance abuse, Outpatient addiction treatment Midtown Manhattan, drug Rehab Midtown Manhattan, intensive outpatient program Midtown Manhattan, IOP near me, alcohol counseling near me
+    output: false
   how-we-treat:
     title: How We Treat
     output: true
@@ -56,9 +64,10 @@ defaults:
   values:
     layout: post
     permalink: "/blog/:title/"
-    author: 
-    post_image: 
-    seo_keywords: 
+    author:
+    post_image:
+    seo_description:
+    seo_keywords:
 - scope:
     path: ''
     type: pages
@@ -71,7 +80,7 @@ defaults:
     permalink: "/blog/authors/:title/"
     layout: author
     credentials: Ph.D.
-    medium: 
+    medium:
 description: Elevate360 is a boutique addiction treatment program in Midtown Manhattan.
 seo_subtitle: Outpatient addiction treatment in Midtown Manhattan
 seo_site_keywords: addiction, addiction treatment, mental health treatment

--- a/_how-we-treat/group-psychotherapy.markdown
+++ b/_how-we-treat/group-psychotherapy.markdown
@@ -1,5 +1,7 @@
 ---
 title: Group Psychotherapy
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 4
 back_href: "/why-elevate360/how-we-treat/"

--- a/_how-we-treat/individual-psychotherapy .markdown
+++ b/_how-we-treat/individual-psychotherapy .markdown
@@ -1,5 +1,7 @@
 ---
 title: Individual Psychotherapy
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 3
 back_href: "/why-elevate360/how-we-treat/"
@@ -7,6 +9,6 @@ back_title: How We Treat
 layout: tertiary
 ---
 
-At Elevate360 all patients participate in individual sessions provided by psychologists who have expertise in treating both substance use disorders and the psychological issues that frequently occur along with alcohol and drug use, some of which include anxiety, low mood, trauma, chronic pain and compulsive behaviors.  Our therapists use multiple proven therapies including motivational and cognitive behavioral therapy and will supplement with other therapies as appropriate based on the needs of the individual patient. 
+At Elevate360 all patients participate in individual sessions provided by psychologists who have expertise in treating both substance use disorders and the psychological issues that frequently occur along with alcohol and drug use, some of which include anxiety, low mood, trauma, chronic pain and compulsive behaviors.  Our therapists use multiple proven therapies including motivational and cognitive behavioral therapy and will supplement with other therapies as appropriate based on the needs of the individual patient.
 
-Patients may focus on individual treatment or they may also participate in various group sessions to supplement their individual work.  Additionally, for those patients who are already engaged in treatment, our psychologists can coordinate Elevate360 care with outside care providers including psychiatrists, therapists, nutritionists, recovery coaches and others. 
+Patients may focus on individual treatment or they may also participate in various group sessions to supplement their individual work.  Additionally, for those patients who are already engaged in treatment, our psychologists can coordinate Elevate360 care with outside care providers including psychiatrists, therapists, nutritionists, recovery coaches and others.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,8 +6,19 @@
 {% if page.layout == 'post' %}
     {% assign is_blog = true %}
 {% endif %}
+
+
+{% assign seo_source_collection = site.collections | where: "title", page.seo_source_collection | first %}
+{% if seo_source_collection %}
+  {% assign page_title = seo_source_collection.page_title %}
+{% endif %}
+
+{% if page.title %}
+  {% assign page_title = page.title %}
+{% endif %}
+
 <title>
-  {{ page.title }}{% if is_blog %} | Blog {% endif %}{% unless is_root %} | {{ site.title }}{% endunless %} – {{ site.seo_subtitle }}
+  {{ page_title }}{% if is_blog %} | Blog {% endif %}{% unless is_root %} | {{ site.title }}{% endunless %} – {{ site.seo_subtitle }}
 </title>
 
 <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,400i,500,700,700i,900,900i" rel="stylesheet">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,8 @@
 
 {% assign seo_source_collection = site.collections | where: "title", page.seo_source_collection | first %}
 {% if seo_source_collection %}
-{% assign keywords = seo_source_collection.seo_keywords %}
+  {% assign keywords = seo_source_collection.seo_keywords %}
+  {% assign description = seo_source_collection.seo_description %}
 {% endif %}
 
 {% if page['seo_keywords'] %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 {% assign keywords = site.seo_site_keywords %}
+{% assign description = site.description %}
 {% if page['seo_keywords'] %}
   {% assign keywords = page['seo_keywords'] %}
+{% endif %}
+{% if page['seo_description'] %}
+  {% assign description = page['seo_description'] %}
 {% endif %}
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
@@ -9,6 +13,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="index, follow">
     <meta name="keywords" content="{{ keywords }}">
+    <meta name="description" content="{{ description }}">
     {% feed_meta %}
 
     {% include head.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,12 +1,21 @@
 <!DOCTYPE html>
 {% assign keywords = site.seo_site_keywords %}
 {% assign description = site.description %}
+
+{% assign seo_source_collection = site.collections | where: "title", page.seo_source_collection | first %}
+{% if seo_source_collection %}
+{% assign keywords = seo_source_collection.seo_keywords %}
+{% endif %}
+
 {% if page['seo_keywords'] %}
   {% assign keywords = page['seo_keywords'] %}
 {% endif %}
+
 {% if page['seo_description'] %}
   {% assign description = page['seo_description'] %}
 {% endif %}
+
+
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />

--- a/_therapies-used/cognitive-behavioral-therapy.markdown
+++ b/_therapies-used/cognitive-behavioral-therapy.markdown
@@ -1,5 +1,7 @@
 ---
 title: Cognitive Behavioral Therapy (CBT)
+seo_description:
+seo_keywords:
 date: 2018-09-07 16:22:00 -04:00
 position: 1
 back_href: "/why-elevate360/therapies-used/"

--- a/_therapies-used/community-reinforcement-approach-and-family-therapy.markdown
+++ b/_therapies-used/community-reinforcement-approach-and-family-therapy.markdown
@@ -1,5 +1,7 @@
 ---
 title: Community Reinforcement Approach and Family Therapy (CRAFT)
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 5
 back_href: "/why-elevate360/therapies-used/"
@@ -7,6 +9,6 @@ back_title: Therapies Used
 layout: tertiary
 ---
 
-Community Reinforcement Approach and Family Therapy (CRAFT) is a treatment approach designed specifically for people who are concerned about a loved one who is drinking or using drugs.  Developed by Dr. Robert Meyers at the University of New Mexico, this positive treatment approach can be delivered individually or in groups and leads to reduced conflict in the family and a healthier and more sustainable life for the people who are caring for someone that is struggling with alcohol or drug use. 
+Community Reinforcement Approach and Family Therapy (CRAFT) is a treatment approach designed specifically for people who are concerned about a loved one who is drinking or using drugs.  Developed by Dr. Robert Meyers at the University of New Mexico, this positive treatment approach can be delivered individually or in groups and leads to reduced conflict in the family and a healthier and more sustainable life for the people who are caring for someone that is struggling with alcohol or drug use.
 
 This approach utilizes non-confrontational behavioral principles to help the loved one become motivated to enter treatment which include finding and rewarding positive behaviors and allowing the loved one to experience the natural consequences of their use. Using these methods, families can learn to change their interactions with their loved one which result in changes in their loved one’s behavior. In repeated clinical studies, the CRAFT approach has been proven to be significantly more effective than both the Johnson Intervention and Al-Anon at convincing a loved one to enter treatment. CRAFT methods provide families with hopeful, positive, and effective alternatives to addressing alcohol and substance problems in their families.

--- a/_therapies-used/community-reinforcement-approach.markdown
+++ b/_therapies-used/community-reinforcement-approach.markdown
@@ -1,5 +1,7 @@
 ---
 title: Community Reinforcement Approach (CRA)
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 4
 back_href: "/why-elevate360/therapies-used/"
@@ -9,4 +11,4 @@ layout: tertiary
 
 The community-reinforcement approach aims to move people towards recovery by eliminating positive reinforcement for drinking and drug use and enhancing positive reinforcement for non-drinking and drug using behaviors and activities. This approach integrates several treatment components, including building motivation to quit, analyzing drinking patterns, increasing pleasurable activities, learning new coping behaviors, and involving significant others in the recovery process.
 
-Therapists may encourage patients to include another individual in their treatment with whom they spend a lot of time (e.g., significant other) to help recognize triggers that may be more difficult for the individual to notice (e.g., irritability). During the treatment, the patient learns practical skills to meet his or her goals including communication, problem solving, and assertive drink and drug refusal (i.e., effective ways to manage invitations to drink or use drugs). The overall goal of CRA is to help individuals find healthier ways to meet their social and emotional needs. 
+Therapists may encourage patients to include another individual in their treatment with whom they spend a lot of time (e.g., significant other) to help recognize triggers that may be more difficult for the individual to notice (e.g., irritability). During the treatment, the patient learns practical skills to meet his or her goals including communication, problem solving, and assertive drink and drug refusal (i.e., effective ways to manage invitations to drink or use drugs). The overall goal of CRA is to help individuals find healthier ways to meet their social and emotional needs.

--- a/_therapies-used/mindfulness-based-relapse-prevention.markdown
+++ b/_therapies-used/mindfulness-based-relapse-prevention.markdown
@@ -1,5 +1,7 @@
 ---
 title: Mindfulness Based Relapse Prevention (MBRP)
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 3
 back_href: "/why-elevate360/therapies-used/"
@@ -7,6 +9,6 @@ back_title: Therapies Used
 layout: tertiary
 ---
 
-Mindfulness Based Relapse Prevention (MBRP) integrates core aspects of relapse prevention with practices that teach stress reduction and cognitive behavioral therapy.   During this treatment, patients learn to recognize early warning signs for relapse, increase awareness of internal and external cues associated with alcohol and substance use, and develop effective coping skills. Additionally, mindfulness practices raise awareness of triggers, assist in monitoring internal reactions, and foster more skillful behavioral choices. 
+Mindfulness Based Relapse Prevention (MBRP) integrates core aspects of relapse prevention with practices that teach stress reduction and cognitive behavioral therapy.   During this treatment, patients learn to recognize early warning signs for relapse, increase awareness of internal and external cues associated with alcohol and substance use, and develop effective coping skills. Additionally, mindfulness practices raise awareness of triggers, assist in monitoring internal reactions, and foster more skillful behavioral choices.
 
 Patients also learn to increase their acceptance and tolerance of various physical, emotional, and cognitive states, especially craving, thereby reducing the likelihood of utilizing substances to alleviate discomfort. In the event of a recurrence of alcohol or substance use awareness and acceptance fostered by mindfulness may aid in recognition and minimization of the blame, guilt, and negative thinking that increase risk of continued use. 

--- a/_therapies-used/psychological-treatment-for-chronic-pain.markdown
+++ b/_therapies-used/psychological-treatment-for-chronic-pain.markdown
@@ -1,5 +1,7 @@
 ---
 title: Psychological Treatment for Chronic Pain
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 6
 back_href: "/why-elevate360/therapies-used/"
@@ -7,8 +9,8 @@ back_title: Therapies Used
 layout: tertiary
 ---
 
-Many medical practitioners treat pain exclusively as a medical problem.  But at Elevate360, we think of pain as a biopsychosocial condition and we pay careful attention to the psychological and social aspects of pain in the context of the medical disorder. Psychological treatment can provide people with tools to better control their experience of pain.  Our treatment also focuses on helping people learn ways to manage all aspects of self-care so that they are best able to utilize pain management techniques. 
+Many medical practitioners treat pain exclusively as a medical problem.  But at Elevate360, we think of pain as a biopsychosocial condition and we pay careful attention to the psychological and social aspects of pain in the context of the medical disorder. Psychological treatment can provide people with tools to better control their experience of pain.  Our treatment also focuses on helping people learn ways to manage all aspects of self-care so that they are best able to utilize pain management techniques.
 
-We emphasize the engagement of our patients in organizing and managing their daily routines to improve overall functioning and to reduce reliance on medications for pain. 
+We emphasize the engagement of our patients in organizing and managing their daily routines to improve overall functioning and to reduce reliance on medications for pain.
 
 Our individual and group therapists utilize techniques developed by Dr. Beth Darnall, a psychologist and researcher at Stanford University who has designed psychological treatments specifically for people with chronic pain.  She has conducted research to prove the effectiveness of these techniques which include diaphragmatic breathing, meditation, and progressive relaxation.  These and other strategies assist patients in reducing their stress levels, muscular tension and emotional distress, all with the goal of reducing pain.  Our therapists assist patients in learning and practicing multiple techniques to reduce anxiety and pain throughout the day and at the end of day when falling asleep

--- a/_trainings/advanced-sbirt.markdown
+++ b/_trainings/advanced-sbirt.markdown
@@ -1,5 +1,7 @@
 ---
 title: Advanced Screening, Brief Intervention and Referral to Treatment (SBIRT)
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 5
 back_href: "/services/trainings-for-clinicians"

--- a/_trainings/intro-sbirt.markdown
+++ b/_trainings/intro-sbirt.markdown
@@ -1,5 +1,7 @@
 ---
 title: Introduction to Screening, Brief Intervention, and Referral to Treatment (SBIRT)
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 4
 back_href: "/services/trainings-for-clinicians"

--- a/_trainings/motivational-interviewing.markdown
+++ b/_trainings/motivational-interviewing.markdown
@@ -1,5 +1,7 @@
 ---
 title: Motivational Interviewing Training
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 tags:
 - motivational interviewing

--- a/_trainings/oopp.markdown
+++ b/_trainings/oopp.markdown
@@ -1,5 +1,7 @@
 ---
 title: Opioid Overdose Prevention Program (OOPP)
+seo_keywords:
+seo_description:
 date: 2018-12-06 15:13:00 -05:00
 tags:
 - overdose prevention

--- a/_treatment-programs/additional-services.markdown
+++ b/_treatment-programs/additional-services.markdown
@@ -1,5 +1,7 @@
 ---
 title: Additional Services
+seo_keywords:
+seo_description:
 date: 2018-09-07 16:22:00 -04:00
 position: 4
 back_href: "/services/treatment-programs"
@@ -10,5 +12,3 @@ layout: tertiary
 DWI Screening and Assessment is available on site for those who need to be evaluated.
 
 Additional services including family and couples therapy may be added to the individualized treatment plan for individuals depending on their needs.
-
- 

--- a/about-us.html
+++ b/about-us.html
@@ -1,5 +1,4 @@
 ---
-title: About Us
 seo_source_collection: About Us
 date: 2018-10-25 00:42:00 -04:00
 layout: default

--- a/about-us.html
+++ b/about-us.html
@@ -1,5 +1,6 @@
 ---
 title: About Us
+seo_source_collection: About Us
 date: 2018-10-25 00:42:00 -04:00
 layout: default
 background-image: hero@2x.jpg

--- a/blog.html
+++ b/blog.html
@@ -1,5 +1,6 @@
 ---
 title: Blog
+seo_source_collection: Posts
 date: 2018-10-25 00:45:00 -04:00
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 ---
-title: Welcome to Elevate360 Wellness
 seo_source_collection: Home
 date: 2018-08-26 01:08:00 -04:00
 crumbtitle: Home

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 title: Welcome to Elevate360 Wellness
+seo_source_collection: Home
 date: 2018-08-26 01:08:00 -04:00
 crumbtitle: Home
 background-image: "/uploads/sarah-dorweiler-211779-unsplash@2x.png"

--- a/services.markdown
+++ b/services.markdown
@@ -1,5 +1,7 @@
 ---
 title: Services
+seo_description:
+seo_keywords:
 date: 2018-10-28 11:47:00 -04:00
 layout: services_main
 h2: Compassionate care, effectively done

--- a/services/treatment-programs.markdown
+++ b/services/treatment-programs.markdown
@@ -1,5 +1,7 @@
 ---
 title: Treatment Programs
+seo_keywords:
+seo_description:
 date: 2018-10-28 11:51:00 -04:00
 collection: treatment-programs
 footer-section:

--- a/services/treatment-programs/group-psychotherapy-offerings.html
+++ b/services/treatment-programs/group-psychotherapy-offerings.html
@@ -2,6 +2,7 @@
 title: Group Psychotherapy Offerings
 layout: default
 collection: group-psychotherapy
+seo_source_collection: Group Psychotherapy
 back_href: "/services/treatment-programs"
 back_title: Treatment Programs
 ---

--- a/why-elevate360.markdown
+++ b/why-elevate360.markdown
@@ -7,9 +7,8 @@ h2: In short, because we do treatment right.
 hero-content: Our professional staff uses proven therapeutic techniques and technology
   to provide care which aims to help each patient develop a meaningful life in recovery
   that is more compelling than a life consumed with substance use.
-seo_keywords: "therapeutic techniques, therapeutic techniques for anxiety, evidence
-  based treatment addiction Manhattan, Addiction psychologists, Addiction experts,
-  Science-based health technology\n\n"
+seo_keywords: therapeutic techniques, therapeutic techniques for anxiety, evidence-based treatment addiction Manhattan, Addiction psychologists, Addiction experts, Science-based health technology
+seo_description: Elevate360 is advancing addiction treatment by using therapeutic techniques and science-based health technology to support recovery and wellness. Consult our expert psychologists.
 layout: why_elevate360
 ---
 

--- a/why-elevate360/how-we-treat.markdown
+++ b/why-elevate360/how-we-treat.markdown
@@ -1,5 +1,7 @@
 ---
 title: How We Treat
+seo_keywords:
+seo_description:
 date: 2018-10-28 11:51:00 -04:00
 collection: how-we-treat
 layout: services

--- a/why-elevate360/our-technology.markdown
+++ b/why-elevate360/our-technology.markdown
@@ -1,5 +1,7 @@
 ---
 title: Our Technology
+seo_keywords:
+seo_description:
 date: 2018-10-28 11:51:00 -04:00
 layout: our_technology
 background-image: hero-technology@2x.jpg

--- a/why-elevate360/therapies-used.markdown
+++ b/why-elevate360/therapies-used.markdown
@@ -1,5 +1,7 @@
 ---
 title: Therapies Used
+seo_keywords:
+seo_description:
 date: 2018-10-28 11:51:00 -04:00
 collection: therapies-used
 footer-section:


### PR DESCRIPTION
## SEO Metadata Fields: `title`, `seo_description`, `seo_keywords`

Collections: Set in `_config.yml`, or on Siteleaf under Collection Settings.
Pages: Set directly on the page metadata.

Resolves #172 

## Tips

* For HTML pages which are the front page of a collection:
  * Front matter should NOT have `title` field (delete it if present)
  * MUST have `seo_source_collection` field set
  * In `_config.yml`, MUST have `page_title`, `seo_keywords` and `seo_description` under that collection
* For Markdown pages:
  * Must have `title`, `seo_keywords`, and `seo_description` fields set
* For Markdown pages that are the front page of a `collection`:
  * Don't bother with `_config.yml` fields; just set fields the same as for regular Markdown pages.

## How SEO `<meta>` and `<title>` tags are set

### `title`:

1. Look for `seo_source_collection` metadata field.
1. If present, the page title will be set by the `page_title` field under that collection.
1. If `page.title` is present, it will use that instead.

### `seo_keywords` and `seo_description`:

1. First, start with `site.seo_site_keywords` and site.description.
1. Then, look for the `seo_source_collection` metadata field.
1. If present, `seo_keywords` and `seo_description` will be set by the values under that collection.
1. If `page.seo_keywords` or `page.seo_description` are present, those will be used instead.


### Example 1:

The site has `site.seo_keywords` set to "Hi this is my site."
A page has no `seo_keywords` and no `seo_description` set.  It also has no `seo_source_collection` field.
_Result:_ The `seo_keywords` will be "Hi this is my site."

### Example 2:

A page has the `seo_source_collection` field set to About Us.
In Siteleaf in the About Us Collection settings, the seo_keywords are set to "about us keywords."
The page has no `page.seo_keywords` set.

_Result:_ The `seo_keywords` will be set to "about us keywords".

### Example 3:

A page has the `seo_source_collection` field set to About Us.
In Siteleaf in the About Us Collection settings, the `seo_keywords` are set to "about us keywords."
The page also has `page.seo_keywords` set to "these keywords will win!"

_Result:_ The `seo_keywords` will be set to "these keywords will win!"
